### PR TITLE
Text disappearing in Dark Mode

### DIFF
--- a/ChatDemo-UI3.0/Code/Controllers/Base.lproj/AgoraLoginViewController.xib
+++ b/ChatDemo-UI3.0/Code/Controllers/Base.lproj/AgoraLoginViewController.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -35,7 +36,7 @@
                         </imageView>
                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Hyphenate ID" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="LmY-eG-rqi">
                             <rect key="frame" x="32" y="224" width="349" height="50"/>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="50" id="3Ln-YR-BY8"/>
                             </constraints>
@@ -47,7 +48,7 @@
                         </textField>
                         <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Password" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="IgV-CU-0WE">
                             <rect key="frame" x="32" y="289" width="349" height="50"/>
-                            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                            <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="50" id="PAr-PJ-wZ2"/>
                             </constraints>
@@ -138,5 +139,8 @@
     </objects>
     <resources>
         <image name="Logo_green.png" width="200" height="71"/>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
     </resources>
 </document>


### PR DESCRIPTION
Placeholder text was not appearing when device used **dark mode** previously, as illustrated:

Previous version in dark mode (left), updated background colours in dark mode (right)
<img src="https://user-images.githubusercontent.com/5754073/125609161-3964b944-aded-4ccc-963d-cb0e75593d7f.PNG" width="300px"/><img src="https://user-images.githubusercontent.com/5754073/125609184-cadadc00-ce7c-41be-8f51-a67cfeeef814.PNG" width="300px" align="right"/>
